### PR TITLE
feat(cli): add --delete, --dry-run, and --yes flags

### DIFF
--- a/devbroom/app.py
+++ b/devbroom/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from .cli import format_targets_table, scan_targets, write_json_report
+from .cli import delete_targets, format_targets_table, scan_targets, write_json_report
 from .scanner import human_size
 from .settings import load_settings
 
@@ -14,6 +14,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--path", type=Path, help="Root directory to scan.")
     parser.add_argument("--json-out", type=Path, help="Write scan results to a JSON file.")
     parser.add_argument("--no-settings-ignores", action="store_true", help="Ignore saved ignore paths.")
+    parser.add_argument("--delete", action="store_true", help="Delete all discovered targets after scanning.")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be deleted without removing anything.")
+    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt when deleting.")
     return parser
 
 
@@ -24,7 +27,18 @@ def run_gui() -> None:
     app.mainloop()
 
 
-def run_cli(root: Path | None, json_out: Path | None, use_settings_ignores: bool) -> int:
+def run_cli(
+    root: Path | None,
+    json_out: Path | None,
+    use_settings_ignores: bool,
+    delete: bool = False,
+    dry_run: bool = False,
+    yes: bool = False,
+) -> int:
+    if delete and dry_run:
+        print("Error: --delete and --dry-run are mutually exclusive.")
+        return 1
+
     settings = load_settings()
     scan_root = (root or Path(settings.last_path or Path.home())).expanduser()
     if not scan_root.is_dir():
@@ -35,14 +49,22 @@ def run_cli(root: Path | None, json_out: Path | None, use_settings_ignores: bool
     targets = scan_targets(scan_root, ignored_paths=ignored_paths)
     print(format_targets_table(targets))
 
-    if json_out:
-        write_json_report(targets, json_out)
-        print(f"JSON report written to {json_out}")
-
     if ignored_paths:
         print(f"Using {len(ignored_paths)} ignored path(s).")
     print(f"Scan root: {scan_root}")
     print(f"Total reclaimable size: {human_size(sum(target.size for target in targets))}")
+
+    if dry_run:
+        print("\nDRY RUN — nothing deleted.")
+        return 0
+
+    if delete and targets:
+        return delete_targets(targets, json_out=json_out, yes=yes)
+
+    if json_out:
+        write_json_report(targets, json_out)
+        print(f"JSON report written to {json_out}")
+
     return 0
 
 
@@ -51,7 +73,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.cli:
-        return run_cli(args.path, args.json_out, use_settings_ignores=not args.no_settings_ignores)
+        return run_cli(
+            args.path,
+            args.json_out,
+            use_settings_ignores=not args.no_settings_ignores,
+            delete=args.delete,
+            dry_run=args.dry_run,
+            yes=args.yes,
+        )
 
     run_gui()
     return 0

--- a/devbroom/cli.py
+++ b/devbroom/cli.py
@@ -4,6 +4,7 @@ import json
 import threading
 from pathlib import Path
 
+from .cleanup import delete_tree
 from .models import ScanTarget
 from .scanner import human_size, iter_scan_targets
 
@@ -52,6 +53,45 @@ def format_targets_table(targets: list[ScanTarget]) -> str:
 def write_text_report(targets: list[ScanTarget], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(format_targets_table(targets) + "\n", encoding="utf-8")
+
+
+def delete_targets(targets: list[ScanTarget], json_out: Path | None = None, yes: bool = False) -> int:
+    total_size = human_size(sum(t.size for t in targets))
+    print(f"\nAbout to delete {len(targets)} folder(s) totaling {total_size}.")
+    if not yes:
+        answer = input("Proceed? [y/N] ").strip().lower()
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return 0
+
+    succeeded: list[ScanTarget] = []
+    failed: list[tuple[ScanTarget, str]] = []
+    for target in targets:
+        try:
+            delete_tree(target.path)
+            succeeded.append(target)
+            print(f"  Deleted  {target.path}")
+        except Exception as exc:
+            failed.append((target, str(exc)))
+            print(f"  FAILED   {target.path}  ({exc})")
+
+    print(f"\nDeleted {len(succeeded)}/{len(targets)} folder(s).")
+    if failed:
+        print(f"{len(failed)} deletion(s) failed — see above for details.")
+
+    if json_out:
+        payload = {
+            "deleted_count": len(succeeded),
+            "failed_count": len(failed),
+            "total_size_bytes": sum(t.size for t in succeeded),
+            "deleted": serialize_targets(succeeded),
+            "failed": [{"path": str(t.path), "error": err} for t, err in failed],
+        }
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"JSON report written to {json_out}")
+
+    return 0 if not failed else 1
 
 
 def write_json_report(targets: list[ScanTarget], output_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,89 @@ class CliTests(unittest.TestCase):
         self.assertEqual(args.json_out, Path("out.json"))
         self.assertTrue(args.no_settings_ignores)
 
+    def test_build_parser_parses_delete_flags(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["--cli", "--path", "demo", "--delete", "--yes"])
+
+        self.assertTrue(args.delete)
+        self.assertTrue(args.yes)
+        self.assertFalse(args.dry_run)
+
+    def test_build_parser_parses_dry_run_flag(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["--cli", "--path", "demo", "--dry-run"])
+
+        self.assertTrue(args.dry_run)
+        self.assertFalse(args.delete)
+
+    def test_dry_run_prints_banner_and_does_not_delete(self) -> None:
+        node_modules = self.workdir / "app" / "node_modules"
+        node_modules.mkdir(parents=True)
+        (node_modules / "package.json").write_text("{}", encoding="ascii")
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run_cli(self.workdir, None, use_settings_ignores=False, dry_run=True)
+
+        output = buffer.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("DRY RUN", output)
+        self.assertTrue(node_modules.exists(), "--dry-run must not delete anything")
+
+    def test_delete_with_yes_removes_targets(self) -> None:
+        node_modules = self.workdir / "app" / "node_modules"
+        node_modules.mkdir(parents=True)
+        (node_modules / "package.json").write_text("{}", encoding="ascii")
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run_cli(self.workdir, None, use_settings_ignores=False, delete=True, yes=True)
+
+        output = buffer.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertFalse(node_modules.exists(), "node_modules should have been deleted")
+        self.assertIn("Deleted", output)
+
+    def test_delete_and_dry_run_are_mutually_exclusive(self) -> None:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run_cli(self.workdir, None, use_settings_ignores=False, delete=True, dry_run=True)
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("mutually exclusive", buffer.getvalue())
+
+    def test_delete_writes_json_report(self) -> None:
+        node_modules = self.workdir / "app" / "node_modules"
+        node_modules.mkdir(parents=True)
+        (node_modules / "package.json").write_text("{}", encoding="ascii")
+        report_path = self.workdir / "deleted.json"
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run_cli(
+                self.workdir, report_path, use_settings_ignores=False, delete=True, yes=True
+            )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["deleted_count"], 1)
+        self.assertEqual(payload["failed_count"], 0)
+        self.assertEqual(len(payload["deleted"]), 1)
+
+    def test_delete_aborts_on_no_confirmation(self) -> None:
+        node_modules = self.workdir / "app" / "node_modules"
+        node_modules.mkdir(parents=True)
+        (node_modules / "package.json").write_text("{}", encoding="ascii")
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            with patch("builtins.input", return_value="n"):
+                exit_code = run_cli(self.workdir, None, use_settings_ignores=False, delete=True, yes=False)
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(node_modules.exists(), "node_modules should NOT be deleted when user says no")
+        self.assertIn("Aborted", buffer.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Resolves #2

Adds three new flags to headless CLI mode, making it viable for automation workflows, CI pipelines, and remote servers where no GUI is available.

| Flag | Behaviour |
|---|---|
| `--dry-run` | Scans and prints the table, then prints a "DRY RUN — nothing deleted" banner. Filesystem is untouched. |
| `--delete` | Deletes all discovered targets after scanning. Prompts for confirmation. |
| `--delete --yes` / `--delete -y` | Deletes without prompting — safe for scripts and CI. |
| `--delete --json-out <file>` | Writes a deletion report (deleted count, failed count, per-path results) instead of a scan report. |
| `--delete` + `--dry-run` | Mutually exclusive — exits with code 1 and an error message. |

### Example usage

```bash
# Safe preview — nothing is deleted
python main.py --cli --path /projects --dry-run

# Delete everything, prompt for confirmation
python main.py --cli --path /projects --delete

# Delete everything, no prompt (for CI)
python main.py --cli --path /projects --delete --yes

# Delete and record what was removed
python main.py --cli --path /projects --delete --yes --json-out cleaned.json
```

## Changes

- **`devbroom/app.py`** — three new parser flags; `run_cli()` accepts `delete`, `dry_run`, `yes`; mutual-exclusion guard; delegates deletion to `cli.delete_targets()`
- **`devbroom/cli.py`** — new `delete_targets()` function: confirmation prompt, per-path deletion with error reporting, optional JSON deletion report
- **`tests/test_cli.py`** — 6 new tests: parser flags, dry-run no-op, delete with `--yes`, mutual-exclusion error, JSON report after delete, abort on "n" confirmation

## Test plan

- [x] All 34 existing tests still pass (`python -m unittest discover -s tests -v`)
- [x] 6 new tests covering every acceptance criterion from issue #2
- [x] `--dry-run` verified to leave filesystem unchanged
- [x] `--delete --yes` verified to remove targets
- [x] `--delete` + `--dry-run` verified to return exit code 1
- [x] JSON report structure verified after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)