### PR TITLE
feat: add __version__ and expose via --version / -V flag

### DIFF
--- a/devbroom/__init__.py
+++ b/devbroom/__init__.py
@@ -1,2 +1,4 @@
 """DevBroom package."""
 
+__version__ = "0.1.0"
+

--- a/devbroom/app.py
+++ b/devbroom/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from . import __version__
 from .cli import delete_targets, format_targets_table, scan_targets, write_json_report
 from .scanner import human_size
 from .settings import load_settings
@@ -10,6 +11,7 @@ from .settings import load_settings
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DevBroom: clean development dependency folders.")
+    parser.add_argument("--version", "-V", action="version", version=f"devBroom {__version__}")
     parser.add_argument("--cli", action="store_true", help="Run in headless CLI mode.")
     parser.add_argument("--path", type=Path, help="Root directory to scan.")
     parser.add_argument("--json-out", type=Path, help="Write scan results to a JSON file.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+import re
+
+from devbroom import __version__
 from devbroom.app import build_parser, run_cli
 from devbroom.cli import format_targets_table, write_json_report, write_text_report
 from devbroom.models import NODE_MODULES_NAME, ScanTarget, VENV_KIND
@@ -120,6 +123,15 @@ class CliTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertIn(str(ignored_target), output)
         self.assertNotIn("Using 1 ignored path(s).", output)
+
+    def test_version_is_non_empty_semver_string(self) -> None:
+        self.assertRegex(__version__, r"^\d+\.\d+\.\d+$")
+
+    def test_version_flag_prints_version_and_exits(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["--version"])
+        self.assertEqual(ctx.exception.code, 0)
 
     def test_build_parser_parses_cli_arguments(self) -> None:
         parser = build_parser()


### PR DESCRIPTION
## Summary

Resolves #4

Adds a single source of truth for the version string and surfaces it in the CLI `--help` output.

## Changes

- **`devbroom/__init__.py`** — defines `__version__ = "0.1.0"`
- **`devbroom/app.py`** — imports `__version__` and adds `--version` / `-V` to `build_parser()` via argparse's built-in `action="version"`
- **`tests/test_cli.py`** — 2 new tests: semver format assertion on `__version__`, and that `--version` exits with code 0

## Usage

```bash
$ python main.py --version
devBroom 0.1.0

$ python main.py -V
devBroom 0.1.0

$ python -c "from devbroom import __version__; print(__version__)"
0.1.0
```

## Test plan

- [x] All 36 tests pass
- [x] `__version__` matches semver pattern `\d+\.\d+\.\d+`
- [x] `--version` exits with code 0
- [x] `--help` now shows `-V, --version` in the options list

🤖 Generated with [Claude Code](https://claude.com/claude-code)