### PR TITLE
feat: add pyproject.toml for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "devbroom"
+dynamic = ["version"]
+description = "Clean development dependency folders (node_modules, virtual envs) to reclaim disk space."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+
+[tool.setuptools.dynamic]
+version = { attr = "devbroom.__version__" }
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["devbroom*"]
+
+[project.scripts]
+devbroom = "devbroom.app:main"


### PR DESCRIPTION
## Summary

Resolves #6

Adds `pyproject.toml` using the modern PEP 621 `[project]` table so the project can be installed via `pip` and exposes a `devbroom` console script entry point.

## Changes

- **`pyproject.toml`** (new file)
  - Build backend: `setuptools.build_meta`
  - Version sourced dynamically from `devbroom.__version__` — single source of truth, no duplication
  - `requires-python = ">=3.10"`
  - `[project.scripts]` entry point: `devbroom = "devbroom.app:main"`

## Usage after install

```bash
pip install -e .        # local dev install
devbroom --version      # devBroom 0.1.0
devbroom --cli --path . # run CLI directly
```

## Test plan

- [x] `pip install -e .` completes without errors
- [x] `devbroom --version` prints `devBroom 0.1.0`
- [x] All 36 existing tests still pass
- [x] No third-party dependencies introduced (stdlib only)