### PR TITLE
ci: expand test matrix to Windows and Python 3.11/3.12

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,18 +10,24 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Run unit tests
         run: python -m unittest discover -s tests


### PR DESCRIPTION
## Summary

Resolves #10

Expands the CI workflow from a single job (Ubuntu + Python 3.12) to a 4-job matrix covering both OS targets and two Python versions.

## Changes

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, windows-latest]
    python-version: ["3.11", "3.12"]
```

- `runs-on` now uses `matrix.os`
- `python-version` now uses `matrix.python-version`
- `fail-fast: false` ensures all 4 jobs always run and report individually rather than cancelling on first failure

## Why this matters

The codebase contains explicit Windows-specific branches:
- `os.name == "nt"` for case-insensitive path detection
- `os.chmod` to remove read-only bits before deletion
- `Scripts/activate` vs `bin/activate` path difference for venv detection

None of these were covered by the Ubuntu-only runner. A regression in any of them would only be caught by a user report.

## Test plan

- [ ] All 4 matrix jobs pass (ubuntu/3.11, ubuntu/3.12, windows/3.11, windows/3.12)