### PR TITLE
chore: prep pyproject.toml and README for PyPI publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ Export results to JSON:
 python3 main.py --cli --path /path/to/projects --json-out scan-report.json
 ```
 
+Preview what would be deleted without removing anything:
+
+```bash
+python3 main.py --cli --path /path/to/projects --dry-run
+```
+
+Delete all discovered targets (with confirmation prompt):
+
+```bash
+python3 main.py --cli --path /path/to/projects --delete
+```
+
+Delete all discovered targets without a confirmation prompt:
+
+```bash
+python3 main.py --cli --path /path/to/projects --delete --yes
+```
+
 CLI output includes:
 
 - matching folders
@@ -250,14 +268,12 @@ The suite is intentionally strongest around non-UI logic. Tkinter widget behavio
 - Scans can be slow on very large directories because folder sizes are calculated recursively.
 - Locked files on Windows may still prevent complete deletion.
 - Tkinter styling can vary across platforms and desktop environments.
-- CLI mode currently scans and reports only; it does not delete folders yet.
 - GUI export currently exports visible rows only, which is usually the right behavior after filtering.
 
 ## Good Next Modifications
 
 - Add an option to sort by largest folders first immediately after scan completion.
 - Add a confirmation detail panel that lists exactly what will be deleted before removal.
-- Add delete support to CLI mode with an explicit `--delete` confirmation flag.
 - Add CSV export if you want results to be easier to open in spreadsheets.
 - Add packaging/install steps once the feature set stabilizes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,22 @@ description = "Clean development dependency folders (node_modules, virtual envs)
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Operating System :: OS Independent",
+  "Topic :: Utilities",
+  "Topic :: System :: Filesystems",
+  "Environment :: Console",
+  "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Homepage = "https://github.com/Sandhu93/devBroom"
+Source = "https://github.com/Sandhu93/devBroom"
+"Bug Tracker" = "https://github.com/Sandhu93/devBroom/issues"
 
 [tool.setuptools.dynamic]
 version = { attr = "devbroom.__version__" }


### PR DESCRIPTION
Closes #16

## Changes

### `pyproject.toml`
- Added `classifiers` — makes the package visible in PyPI category filters (Python version, OS, topic, license)
- Added `[project.urls]` — populates the PyPI sidebar with Homepage, Source, and Bug Tracker links

### `README.md`
- Added CLI usage examples for `--dry-run`, `--delete`, and `--delete --yes`
- Removed stale Known Limitations entry that said CLI cannot delete (shipped in v0.1.0)
- Removed stale Good Next Modifications entry for `--delete` (already done)