### PR TITLE
chore: use SPDX license string and drop deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "devbroom"
 dynamic = ["version"]
 description = "Clean development dependency folders (node_modules, virtual envs) to reclaim disk space."
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -18,7 +18,6 @@ classifiers = [
   "Topic :: Utilities",
   "Topic :: System :: Filesystems",
   "Environment :: Console",
-  "License :: OSI Approved :: MIT License",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes deprecation warnings emitted during `python -m build`. Setuptools>=77 deprecates `license = { text = "MIT" }` in favour of a plain SPDX string (`license = "MIT"`) and also deprecates the `License ::` classifier family. Both are updated here so the build is clean.