### PR TITLE
ci: add workflow to publish to PyPI on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Upload dist as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #19

## What this does

Adds `.github/workflows/publish.yml` — triggers on every published GitHub Release and automatically builds and uploads to PyPI.

## Two jobs

| Job | What it does |
|---|---|
| `build` | Installs `build`, runs `python -m build`, uploads `dist/` as a workflow artifact |
| `publish` | Downloads the artifact, publishes to PyPI via `pypa/gh-action-pypi-publish` using Trusted Publishing |

## Why Trusted Publishing

No API token stored in GitHub secrets. PyPI issues a short-lived OIDC token to the workflow at runtime — more secure and nothing to rotate.

## One-time setup required on PyPI (see below)