### PR TITLE
feat: sort results by largest first and add deletion detail panel

### DIFF
--- a/devbroom/app.py
+++ b/devbroom/app.py
@@ -48,7 +48,11 @@ def run_cli(
         return 1
 
     ignored_paths = () if not use_settings_ignores else settings.ignored_paths
-    targets = scan_targets(scan_root, ignored_paths=ignored_paths)
+    targets = sorted(
+        scan_targets(scan_root, ignored_paths=ignored_paths),
+        key=lambda t: t.size,
+        reverse=True,
+    )
     print(format_targets_table(targets))
 
     if ignored_paths:

--- a/devbroom/cli.py
+++ b/devbroom/cli.py
@@ -57,9 +57,10 @@ def write_text_report(targets: list[ScanTarget], output_path: Path) -> None:
 
 def delete_targets(targets: list[ScanTarget], json_out: Path | None = None, yes: bool = False) -> int:
     total_size = human_size(sum(t.size for t in targets))
-    print(f"\nAbout to delete {len(targets)} folder(s) totaling {total_size}.")
+    print(f"\nAbout to delete {len(targets)} folder(s) totaling {total_size}:")
+    print(format_targets_table(targets))
     if not yes:
-        answer = input("Proceed? [y/N] ").strip().lower()
+        answer = input("\nProceed? [y/N] ").strip().lower()
         if answer not in ("y", "yes"):
             print("Aborted.")
             return 0

--- a/devbroom/ui.py
+++ b/devbroom/ui.py
@@ -638,6 +638,8 @@ class DevBroomApp(tk.Tk):
         status = "Scan stopped." if self._stop_event.is_set() else "Scan complete."
         self._status_var.set(f"{status} Found {count} folder(s).")
         self._update_summary()
+        if count > 0 and not self._stop_event.is_set():
+            self._sort("size")
 
     def _stop_scan(self) -> None:
         self._stop_event.set()
@@ -752,25 +754,108 @@ class DevBroomApp(tk.Tk):
         self._del_btn.config(state="normal")
         self._refresh_all_buttons()
 
+    def _confirm_deletion_panel(self, targets: list[ScanTarget], total_size: int) -> bool:
+        dialog = tk.Toplevel(self)
+        dialog.title("Confirm Deletion")
+        dialog.geometry("800x480")
+        dialog.configure(bg=self._theme.surface)
+        dialog.resizable(True, True)
+        dialog.transient(self)
+        dialog.grab_set()
+
+        result = tk.BooleanVar(value=False)
+
+        header = tk.Frame(dialog, bg=self._theme.surface, padx=20, pady=16)
+        header.pack(fill="x")
+
+        tk.Label(
+            header,
+            text=f"Delete {len(targets)} folder(s) — {human_size(total_size)} will be freed",
+            font=(self._ui_font, 12, "bold"),
+            bg=self._theme.surface,
+            fg=self._theme.danger,
+            anchor="w",
+        ).pack(fill="x")
+
+        tk.Label(
+            header,
+            text="This cannot be undone. Deleted folders are not moved to Trash.",
+            font=(self._ui_font, 9),
+            bg=self._theme.surface,
+            fg=self._theme.text_muted,
+            anchor="w",
+        ).pack(fill="x", pady=(4, 0))
+
+        list_frame = tk.Frame(dialog, bg=self._theme.surface, padx=20, pady=0)
+        list_frame.pack(fill="both", expand=True)
+
+        columns = ("Type", "Size", "Path")
+        tree = ttk.Treeview(
+            list_frame,
+            columns=columns,
+            show="headings",
+            style="Dev.Treeview",
+        )
+        tree.heading("Type", text="Type")
+        tree.heading("Size", text="Size")
+        tree.heading("Path", text="Path")
+        tree.column("Type", width=130, stretch=False, anchor="center")
+        tree.column("Size", width=110, stretch=False, anchor="e")
+        tree.column("Path", width=500, stretch=True)
+        tree.tag_configure("node", background=self._theme.node_bg, foreground=self._theme.node_fg)
+        tree.tag_configure("venv", background=self._theme.venv_bg, foreground=self._theme.venv_fg)
+
+        for target in sorted(targets, key=lambda t: t.size, reverse=True):
+            label = NODE_MODULES_NAME if target.kind == NODE_MODULES_NAME else "virtualenv"
+            tag = "node" if target.kind == NODE_MODULES_NAME else "venv"
+            tree.insert("", "end", values=(label, human_size(target.size), str(target.path)), tags=(tag,))
+
+        vsb = ttk.Scrollbar(list_frame, orient="vertical", command=tree.yview)
+        hsb = ttk.Scrollbar(list_frame, orient="horizontal", command=tree.xview)
+        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        list_frame.rowconfigure(0, weight=1)
+        list_frame.columnconfigure(0, weight=1)
+
+        btn_frame = tk.Frame(dialog, bg=self._theme.surface, padx=20, pady=16)
+        btn_frame.pack(fill="x")
+
+        def on_cancel() -> None:
+            result.set(False)
+            dialog.destroy()
+
+        def on_confirm() -> None:
+            result.set(True)
+            dialog.destroy()
+
+        dialog.protocol("WM_DELETE_WINDOW", on_cancel)
+
+        cancel_btn = self._make_button(btn_frame, "Cancel", on_cancel)
+        cancel_btn.pack(side="right", padx=(8, 0))
+        self._refresh_button(cancel_btn, hovered=False)
+
+        confirm_btn = self._make_button(
+            btn_frame,
+            f"Delete {len(targets)} folder(s)",
+            on_confirm,
+            danger=True,
+        )
+        confirm_btn.pack(side="right")
+        self._refresh_button(confirm_btn, hovered=False)
+
+        dialog.wait_window()
+        return result.get()
+
     def _delete_selected(self) -> None:
         selected_ids = [iid for iid in self._checked if iid in self._items]
         if not selected_ids:
             return
 
-        total_size = sum(self._items[iid].size for iid in selected_ids)
-        count = len(selected_ids)
-        confirmed = messagebox.askyesno(
-            "Confirm deletion",
-            (
-                f"You are about to permanently delete {count} folder(s) "
-                f"({human_size(total_size)}).\n\n"
-                f"{NODE_MODULES_NAME}: restore with npm install / pnpm install / yarn install\n"
-                "venv/.venv: recreate and reinstall requirements as needed\n\n"
-                "This cannot be undone. Proceed?"
-            ),
-            icon="warning",
-        )
-        if not confirmed:
+        targets = [self._items[iid] for iid in selected_ids]
+        total_size = sum(t.size for t in targets)
+        if not self._confirm_deletion_panel(targets, total_size):
             return
 
         deleted = 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,6 +277,44 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
 
+    def test_run_cli_sorts_results_by_size_descending(self) -> None:
+        small = self.workdir / "a" / "node_modules"
+        small.mkdir(parents=True)
+        (small / "package.json").write_text("{}", encoding="ascii")
+
+        large = self.workdir / "b" / "node_modules"
+        large.mkdir(parents=True)
+        (large / "package.json").write_text("{}" * 5000, encoding="ascii")
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run_cli(self.workdir, None, use_settings_ignores=False)
+
+        self.assertEqual(exit_code, 0)
+        output = buffer.getvalue()
+        large_pos = output.find(str(large))
+        small_pos = output.find(str(small))
+        self.assertGreater(large_pos, -1)
+        self.assertGreater(small_pos, -1)
+        self.assertLess(large_pos, small_pos, "larger folder should appear before smaller folder")
+
+    def test_delete_confirmation_shows_detail_table(self) -> None:
+        node_modules = self.workdir / "app" / "node_modules"
+        node_modules.mkdir(parents=True)
+        (node_modules / "package.json").write_text("{}", encoding="ascii")
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            with patch("builtins.input", return_value="n"):
+                exit_code = run_cli(self.workdir, None, use_settings_ignores=False, delete=True, yes=False)
+
+        output = buffer.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("TYPE", output)
+        self.assertIn(str(node_modules), output)
+        # PATH header must appear at least twice: once in scan table, once in detail table
+        self.assertGreaterEqual(output.count("PATH"), 2)
+
     def test_delete_aborts_on_no_confirmation(self) -> None:
         node_modules = self.workdir / "app" / "node_modules"
         node_modules.mkdir(parents=True)


### PR DESCRIPTION
Closes #21

## Changes

### CLI (`app.py`)
- Scan results are sorted by size descending before printing — largest space-savers shown first

### CLI (`cli.py`)
- `delete_targets()` now prints the full detail table before the `Proceed? [y/N]` prompt so the user can review exact paths and sizes before confirming

### GUI (`ui.py`)
- `_scan_done()` calls `self._sort("size")` after a completed scan — table auto-sorts largest-first without a manual click
- `_delete_selected()` now calls `_confirm_deletion_panel()` instead of a generic `messagebox.askyesno`
- New `_confirm_deletion_panel()` — modal Toplevel listing every target (type, size, path) sorted largest-first, with Cancel and Delete buttons; closing via X is treated as Cancel

### Tests (`test_cli.py`)
- `test_run_cli_sorts_results_by_size_descending` — verifies the larger folder appears before the smaller folder in CLI output
- `test_delete_confirmation_shows_detail_table` — verifies the detail table (TYPE/PATH headers) appears in the delete confirmation output

## Test results
43 tests passed, 0 failed