### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/devbroom/__init__.py
+++ b/devbroom/__init__.py
@@ -1,4 +1,4 @@
 """DevBroom package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 


### PR DESCRIPTION
Bumps `__version__` from `0.1.0` → `0.1.1` ahead of the v0.1.1 release.

## Changes in this release
- Sort scan results by largest folder first (UI + CLI)
- Deletion detail panel showing exactly what will be deleted before confirmation
- Skip targets not inside a git repository by default (`--include-non-project` to opt out)

## After merging
Create GitHub Release `v0.1.1` — the `publish.yml` workflow will build and push to PyPI automatically.